### PR TITLE
Update Ubuntu-Install-Debs.rst

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -99,7 +99,7 @@ Talker-listener
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication.
+First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication. The Zenoh RMW (rmw_zenoh_cpp) is optional and not installed by default with ``ros-{DISTRO}-desktop``. If you are using the default FastDDS, you can skip this first step.
 
 In one terminal, start the Zenoh router daemon:
 


### PR DESCRIPTION
Clarification on Zenoh in the 'trying out examples' section.

## Description

This PR clarifies the "Trying out examples" section after a fresh installation of ROS 2 Humble.

Currently, the documentation suggests starting a Zenoh router (ros2 run rmw_zenoh_cpp rmw_zenohd), but Zenoh is not included in the default ros-humble-desktop installation. Following this step directly will result in an error for new users.

The update makes it clear that:

Zenoh is optional and requires separate installation if users explicitly want to use it.

This should prevent confusion for beginners trying the basic talker/listener example after installation.

